### PR TITLE
taskブランチのMockitoAnnotations.openMocksの削除

### DIFF
--- a/src/test/java/jp/co/solxyz/jsn/academy/junitsample/application/service/impl/BookManagementServiceImplTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/academy/junitsample/application/service/impl/BookManagementServiceImplTest.java
@@ -2,13 +2,11 @@ package jp.co.solxyz.jsn.academy.junitsample.application.service.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,11 +35,6 @@ class BookManagementServiceImplTest {
 
 	@Mock
 	BookOrderApi bookOrderApi;
-
-	@BeforeEach
-	public void setup() {
-		MockitoAnnotations.openMocks(this);
-	}
 
 	@Test
 	void test() {


### PR DESCRIPTION
Issue #1 

taskブランチのMockitoAnnotations.openMocksを削除しました