### PR TITLE
MockBeanは非推奨になったためMockitoBeanに変更

### DIFF
--- a/src/test/java/jp/co/solxyz/jsn/academy/junitsample/application/controller/BookManagementScreenControllerTest.java
+++ b/src/test/java/jp/co/solxyz/jsn/academy/junitsample/application/controller/BookManagementScreenControllerTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import jp.co.solxyz.jsn.academy.junitsample.application.service.BookManagementService;
@@ -25,7 +25,7 @@ class BookManagementScreenControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
 
-	@MockBean
+	@MockitoBean
 	private BookManagementService bookManagementService;
 
 	@Nested


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes

MockBeanは非推奨だと警告が出るため、推奨されるMockitoBeanに移行